### PR TITLE
allow for arbitrary tilejson URLs

### DIFF
--- a/models/Project.bones
+++ b/models/Project.bones
@@ -1,6 +1,6 @@
 // Extend the Project model schema to allow for extra metadata.
 model = models.Project.augment({
-    mapboxTileJSON: function(mapID) {
+    mapboxTileJSON: function(parent, mapID) {
         return 'http://a.tiles.mapbox.com/v3/' + mapID + '.jsonp';
     }
 });

--- a/models/Project.bones
+++ b/models/Project.bones
@@ -1,7 +1,7 @@
 // Extend the Project model schema to allow for extra metadata.
 model = models.Project.augment({
-    tileJSON: function() {
-        return 'http://a.tiles.mapbox.com/v3/' + this.get('_basemap') + '.jsonp';
+    mapboxTileJSON: function(mapID) {
+        return 'http://a.tiles.mapbox.com/v3/' + mapID + '.jsonp';
     }
 });
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ __Note:__ This plugin is not tested to work with other plugins.
 
 ![](https://f.cloud.github.com/assets/20300/1507626/eaeb09a2-4995-11e3-9bfb-038aa0547da3.png)
 
-- Go to a projects settings, and enter a map ID from your Mapbox.com map in the Mapbox Layer field.
+- Go to a projects settings, and enter a map ID from your Mapbox.com map, or a URL for a TileJSON Service, in the Reference Layer field.
 
 ![](https://f.cloud.github.com/assets/20300/1507627/ecdc5ed2-4995-11e3-824f-2a4fda01e9b8.png)
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 This TileMill plugin adds a custom map as a reference layer to your TileMill projects.
 
+This reference layer will be visible while designing & previewing a map, but will not be included in any exports.
+
 ## Installation
 
 The plugin should be available from the Plugins panel in TileMill.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Reference Layer for TileMill
 
-This TileMill plugin adds Mapbox Streets or a custom map as a reference layer to your TileMill projects.
+This TileMill plugin adds a custom map as a reference layer to your TileMill projects.
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@ __Note:__ This plugin is not tested to work with other plugins.
   
 ![](https://i.cloudup.com/FkgThf6MV4-3000x3000.png)
 
+- If you have a custom tileset available elsewhere, you'll need a TileJSON service to describe this map. You can use the URL of this service for the Reference Layer field.
+
 - Design a map with a transparent `Map` background
 
 - Upload your map to [Mapbox](http://mapbox.com)

--- a/templates/Metadata._
+++ b/templates/Metadata._
@@ -103,9 +103,9 @@ var get = _(project.get).bind(project);
   <% } %>
   <% if (model == project) { %>
   <li>
-    <label for='_basemap'>MapBox layer</label>
+    <label for='_basemap'>Reference layer</label>
     <input type='text' name='_basemap' class='stretch' value='<%= get('_basemap') %>' />
-    <small class='description'>Map ID for reference layer.</small>
+    <small class='description'>Mapbox Map ID or tileJSON URL for reference layer.</small>
   </li>
   <% } %>
   <% if (model !== project && type === 'tiles') { %>

--- a/views/Map.bones
+++ b/views/Map.bones
@@ -48,7 +48,6 @@ view.prototype.render = function(init) {
         //mapbox IDs are of the form 'account.mapid', where account and mapid can't contain url-reserved chars
         if (basemap.match(/^[^/.]+\.[^/.]+$/)) {
             basemap = this.model.mapboxTileJSON(basemap);
-            this.model.set({ '_basemap': basemap });
         }
 
         wax.tilejson(basemap, _(function(tilejson) {

--- a/views/Map.bones
+++ b/views/Map.bones
@@ -44,14 +44,13 @@ view.prototype.render = function(init) {
     var basemap = (this.model.get('_basemap'));
     if (basemap) {
 
-        // If tilejson url stored, replace it with map ID
-        var mapID = basemap.match(/\/v\d\/(.*)\.json/);
-        if (mapID) {
-            basemap = mapID[1] || '';
+        //if a mapbox.com mapID is given, use that to construct the tileJSON url
+        //mapbox IDs are of the form 'account.mapid', where account and mapid can't contain url-reserved chars
+        if (basemap.match(/^[^/.]+\.[^/.]+$/)) {
+            basemap = this.model.mapboxTileJSON(basemap);
             this.model.set({ '_basemap': basemap });
         }
 
-        basemap = this.model.tileJSON();
         wax.tilejson(basemap, _(function(tilejson) {
             // Insert remote map as a layer
             this.map.insertLayerAt(0, new wax.mm.connector(tilejson));


### PR DESCRIPTION
This is a bit of the opposite of what is asked for in issue #6.

In my workflow, I sometimes need to use reference layers that aren't hosted on mapbox.com. For this, full tileJSON URLs should be used to configure reference-layer.

This patch preserves expected behavior when using a MapBox mapID for configuration.
